### PR TITLE
Add requirements for pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+jupyter
+pandas
+numpy
+matplotlib
+scikit-learn
+scipy


### PR DESCRIPTION
It would be useful to describe the packages to install. For example, adding the following lines in the README:

```
virtualenv venv
. venv/bin/activate
pip install -r requirements.txt
```
